### PR TITLE
CoC comunidade em geral

### DIFF
--- a/codigo-de-conduta-comunidade.md
+++ b/codigo-de-conduta-comunidade.md
@@ -39,7 +39,7 @@ Os participantes solicitados a parar com o comportamento inadequado devem fazê-
 
 Representantes de mantenedores, patrocinadores, parceiros, fornecedores e quaisquer atividades similares estão igualmente sujeitos às mesmas regras deste código de conduta. 
 
-Se um participante apresentar comportamento constrangedor, os organizadores do canal podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a espulsão do agressor, sem reembolso do valor pago para participar se aplicável.
+Se um participante apresentar comportamento constrangedor, os organizadores do canal podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a expulsão do agressor, sem reembolso do valor pago para participar se aplicável.
 
 Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contactar um dos evangelistas da comunidade imediatamente. 
 As pessoas responsáveis pela organização em eventos serão apresentadas ao início dos eventos e podem ser facilmente identificados por camisetas e/ou crachás. Nos canais oficiais da comunidade procure um dos evangelistas da comunidade [http://phpsp.org.br/quem-e-a-comunidade/].

--- a/codigo-de-conduta-comunidade.md
+++ b/codigo-de-conduta-comunidade.md
@@ -1,0 +1,59 @@
+## Codigo de Conduta da Comunidade de desenvolvedores PHP do estado de São Paulo
+
+### Versão curta
+
+> O **PHPSP** está comprometido a ser uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
+> Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos e canais organizados pela comunidade.
+> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chats e quaisquer outro canal da comunidade.
+> Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
+> Entendemos como assédio e constrangimento:
+
+> * comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
+> * imagens sexuais em espaços públicos; 
+> * intimidação intencional; 
+> * perseguição;
+> * obtenção de som ou imagem constrangedores;
+> * interrupção continuada e intencional de palestras e/ou eventos paralelos;
+> * contato físico inapropriado; atenção sexual não solicitada;
+
+> Nosso código de conduta pode ser encontrado na íntegra em [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta.md].
+
+### Versão Longa
+
+O **PHPSP** está comprometido a ser uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
+Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos e canais organizados pela comunidade.
+Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossos eventos - isto inclui as palestras, apresentações, exemplos ou demonstrações.
+Os participantes que violarem estas regras podem ser repreendidos, suspensos ou até mesmo expulsos e impedidos de particparem dos canais oficiais da comunidade e seus eventos.
+
+Entendemos como assédio e constrangimento: 
+
+* comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
+* imagens sexuais em espaços públicos; 
+* intimidação intencional; 
+* perseguição;
+* obtenção de som ou imagem constrangedores;
+* interrupção continuada e intencional de palestras e/ou eventos paralelos;
+* contato físico inapropriado; atenção sexual não solicitada;
+
+Os participantes solicitados a parar com o comportamento inadequado devem fazê-lo de imediato.
+
+Representantes de mantenedores, patrocinadores, parceiros, fornecedores e quaisquer atividades similares estão igualmente sujeitos às mesmas regras deste código de conduta. 
+
+Se um participante apresentar comportamento constrangedor, os organizadores do canal podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a espulsão do agressor, sem reembolso do valor pago para participar se aplicável.
+
+Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contactar um dos evangelistas da comunidade imediatamente. 
+As pessoas responsáveis pela organização em eventos serão apresentadas ao início dos eventos e podem ser facilmente identificados por camisetas e/ou crachás. Nos canais oficiais da comunidade procure um dos evangelistas da comunidade [http://phpsp.org.br/quem-e-a-comunidade/].
+
+Embora o desejo seja de que isso não venha a ser necessário, caso seja preciso a organização ajudará os participantes no contato com a segurança do local ou com a polícia ou mesmo providenciando escolta. 
+Faremos o possível para que todos sintam-se confortáveis e seguros.
+
+Contamos com sua compreensão e participação.
+
+* Contato do **PHPSP**: contato@phpsp.org.br
+* Polícia: 190
+* Central de Atendimento à Mulher: 180
+* SAMU: 192
+
+Esperamos que todos os participantes sigam estas recomendações em todos os locais onde o **PHPSP** estiver.
+
+Aproveitem saudavelmente a comunidade!

--- a/codigo-de-conduta-comunidade.md
+++ b/codigo-de-conduta-comunidade.md
@@ -4,7 +4,7 @@
 
 > O **PHPSP** está comprometido a ser uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
 > Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos e canais organizados pela comunidade.
-> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chats e quaisquer outro canal da comunidade.
+> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chat e quaisquer outro canal da comunidade.
 > Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
 > Entendemos como assédio e constrangimento:
 

--- a/codigo-de-conduta-comunidade.md
+++ b/codigo-de-conduta-comunidade.md
@@ -8,7 +8,7 @@
 > Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
 > Entendemos como assédio e constrangimento:
 
-> * comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
+> * comentários que reforçam estruturas sociais de dominação, sejam relacionados a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
 > * imagens sexuais em espaços públicos; 
 > * intimidação intencional; 
 > * perseguição;

--- a/codigo-de-conduta-comunidade.md
+++ b/codigo-de-conduta-comunidade.md
@@ -41,7 +41,7 @@ Representantes de mantenedores, patrocinadores, parceiros, fornecedores e quaisq
 
 Se um participante apresentar comportamento constrangedor, os organizadores do canal podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a expulsão do agressor, sem reembolso do valor pago para participar se aplicável.
 
-Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contactar um dos evangelistas da comunidade imediatamente. 
+Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contatar um dos evangelistas da comunidade imediatamente. 
 As pessoas responsáveis pela organização em eventos serão apresentadas ao início dos eventos e podem ser facilmente identificados por camisetas e/ou crachás. Nos canais oficiais da comunidade procure um dos evangelistas da comunidade [http://phpsp.org.br/quem-e-a-comunidade/].
 
 Embora o desejo seja de que isso não venha a ser necessário, caso seja preciso a organização ajudará os participantes no contato com a segurança do local ou com a polícia ou mesmo providenciando escolta. 

--- a/codigo-de-conduta-eventos.md
+++ b/codigo-de-conduta-eventos.md
@@ -4,7 +4,7 @@
 
 > O **PHPSP** está comprometido a ser uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
 > Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos e canais organizados pela comunidade.
-> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chats e quaisquer outro canal da comunidade.
+> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chat e quaisquer outro canal da comunidade.
 > Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
 > Entendemos como assédio e constrangimento:
 

--- a/codigo-de-conduta-eventos.md
+++ b/codigo-de-conduta-eventos.md
@@ -27,7 +27,7 @@ Os participantes que violarem estas regras podem ser repreendidos, suspensos ou 
 
 Entendemos como assédio e constrangimento: 
 
-* comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
+* comentários que reforçam estruturas sociais de dominação, seja relacionados a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
 * imagens sexuais em espaços públicos; 
 * intimidação intencional; 
 * perseguição;

--- a/codigo-de-conduta-eventos.md
+++ b/codigo-de-conduta-eventos.md
@@ -8,7 +8,7 @@
 > Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
 > Entendemos como assédio e constrangimento:
 
-> * comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
+> * comentários que reforçam estruturas sociais de dominação, sejam relacionados a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
 > * imagens sexuais em espaços públicos; 
 > * intimidação intencional; 
 > * perseguição;

--- a/codigo-de-conduta-eventos.md
+++ b/codigo-de-conduta-eventos.md
@@ -1,0 +1,60 @@
+## Codigo de Conduta da Comunidade de desenvolvedores PHP do estado de São Paulo
+
+### Versão curta
+
+> O **PHPSP** está comprometido a ser uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
+> Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos e canais organizados pela comunidade.
+> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chats e quaisquer outro canal da comunidade.
+> Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
+> Entendemos como assédio e constrangimento:
+
+> * comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
+> * imagens sexuais em espaços públicos; 
+> * intimidação intencional; 
+> * perseguição;
+> * obtenção de som ou imagem constrangedores;
+> * interrupção continuada e intencional de palestras e/ou eventos paralelos;
+> * contato físico inapropriado; atenção sexual não solicitada;
+
+> Nosso código de conduta pode ser encontrado na íntegra em [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta.md].
+
+### Versão Longa
+
+O **PHPSP** está comprometido a oferecer livres de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
+Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos da comunidade.
+Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossos eventos - isto inclui as palestras, apresentações, exemplos ou demonstrações.
+Os participantes que violarem estas regras podem ser repreendidos, suspensos ou até mesmo expulsos e impedidos de particparem dos canais oficiais da comunidade e seus eventos.
+
+Entendemos como assédio e constrangimento: 
+
+* comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
+* imagens sexuais em espaços públicos; 
+* intimidação intencional; 
+* perseguição;
+* obtenção de som ou imagem constrangedores;
+* interrupção continuada e intencional de palestras e/ou eventos paralelos;
+* contato físico inapropriado; atenção sexual não solicitada;
+
+Os participantes solicitados a parar com o comportamento inadequado devem fazê-lo de imediato.
+
+Representantes de mantenedores, patrocinadores, parceiros, fornecedores e quaisquer atividades similares estão igualmente sujeitos às mesmas regras deste código de conduta. 
+Em especial os estandes não devem promover imagens, impressos, atividades ou qualquer outro material com cunho sexual. 
+
+Se um participante apresentar comportamento constrangedor, os organizadores do evento podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a espulsão do agressor, sem reembolso do valor pago para participar se aplicável.
+
+Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contactar um dos evangelistas da comunidade imediatamente. 
+As pessoas responsáveis pela organização em eventos serão apresentadas ao início dos eventos e podem ser facilmente identificados por camisetas e/ou crachás. Nos canais oficiais da comunidade procure um dos evangelistas da comunidade [http://phpsp.org.br/quem-e-a-comunidade/].
+
+Embora o desejo seja de que isso não venha a ser necessário, caso seja preciso a organização ajudará os participantes no contato com a segurança do local ou com a polícia ou mesmo providenciando escolta. 
+Faremos o possível para que todos sintam-se confortáveis e seguros.
+
+Contamos com sua compreensão e participação.
+
+* Contato para eventos do **PHPSP**: eventos@phpsp.org.br
+* Polícia: 190
+* Central de Atendimento à Mulher: 180
+* SAMU: 192
+
+Esperamos que todos os participantes sigam estas recomendações em todos os locais onde o **PHPSP** estiver levando um evento.
+
+Aproveitem saudavelmente o evento!

--- a/codigo-de-conduta-eventos.md
+++ b/codigo-de-conduta-eventos.md
@@ -20,7 +20,7 @@
 
 ### Versão Longa
 
-O **PHPSP** está comprometido a oferecer livres de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
+O **PHPSP** está comprometido a oferecer eventos livres de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
 Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos da comunidade.
 Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossos eventos - isto inclui as palestras, apresentações, exemplos ou demonstrações.
 Os participantes que violarem estas regras podem ser repreendidos, suspensos ou até mesmo expulsos e impedidos de particparem dos canais oficiais da comunidade e seus eventos.

--- a/codigo-de-conduta-eventos.md
+++ b/codigo-de-conduta-eventos.md
@@ -42,7 +42,7 @@ Em especial os estandes não devem promover imagens, impressos, atividades ou qu
 
 Se um participante apresentar comportamento constrangedor, os organizadores do evento podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a expulsão do agressor, sem reembolso do valor pago para participar se aplicável.
 
-Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contactar um dos evangelistas da comunidade imediatamente. 
+Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contatar um dos evangelistas da comunidade imediatamente. 
 As pessoas responsáveis pela organização em eventos serão apresentadas ao início dos eventos e podem ser facilmente identificados por camisetas e/ou crachás. Nos canais oficiais da comunidade procure um dos evangelistas da comunidade [http://phpsp.org.br/quem-e-a-comunidade/].
 
 Embora o desejo seja de que isso não venha a ser necessário, caso seja preciso a organização ajudará os participantes no contato com a segurança do local ou com a polícia ou mesmo providenciando escolta. 

--- a/codigo-de-conduta-eventos.md
+++ b/codigo-de-conduta-eventos.md
@@ -40,7 +40,7 @@ Os participantes solicitados a parar com o comportamento inadequado devem fazê-
 Representantes de mantenedores, patrocinadores, parceiros, fornecedores e quaisquer atividades similares estão igualmente sujeitos às mesmas regras deste código de conduta. 
 Em especial os estandes não devem promover imagens, impressos, atividades ou qualquer outro material com cunho sexual. 
 
-Se um participante apresentar comportamento constrangedor, os organizadores do evento podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a espulsão do agressor, sem reembolso do valor pago para participar se aplicável.
+Se um participante apresentar comportamento constrangedor, os organizadores do evento podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a expulsão do agressor, sem reembolso do valor pago para participar se aplicável.
 
 Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contactar um dos evangelistas da comunidade imediatamente. 
 As pessoas responsáveis pela organização em eventos serão apresentadas ao início dos eventos e podem ser facilmente identificados por camisetas e/ou crachás. Nos canais oficiais da comunidade procure um dos evangelistas da comunidade [http://phpsp.org.br/quem-e-a-comunidade/].

--- a/codigo-de-conduta.md
+++ b/codigo-de-conduta.md
@@ -6,9 +6,19 @@
 > Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos e canais organizados pela comunidade.
 > Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chats e quaisquer outro canal da comunidade.
 > Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
+> Entendemos como assédio e constrangimento:
+
+> * comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
+> * imagens sexuais em espaços públicos; 
+> * intimidação intencional; 
+> * perseguição;
+> * obtenção de som ou imagem constrangedores;
+> * interrupção continuada e intencional de palestras e/ou eventos paralelos;
+> * contato físico inapropriado; atenção sexual não solicitada;
+
 > Nosso código de conduta pode ser encontrado na íntegra em [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta.md].
 
-### Versão Longa
+### Versões longas e específicas 
 
-Comunidade: [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta-comunidade.md]
-Eventos: [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta-eventos.md]
+Código de Conduta Geral da Comunidade: [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta-comunidade.md]
+Código de Conduta para Eventos: [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta-eventos.md]

--- a/codigo-de-conduta.md
+++ b/codigo-de-conduta.md
@@ -4,7 +4,7 @@
 
 > O **PHPSP** está comprometido a ser uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
 > Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos e canais organizados pela comunidade.
-> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chats e quaisquer outro canal da comunidade.
+> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chat e quaisquer outro canal da comunidade.
 > Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
 > Entendemos como assédio e constrangimento:
 

--- a/codigo-de-conduta.md
+++ b/codigo-de-conduta.md
@@ -1,45 +1,14 @@
-## Codigo de Conduta
+## Codigo de Conduta da Comunidade de desenvolvedores PHP do estado de São Paulo
 
 ### Versão curta
 
-> O **PHPSP** está comprometido a oferecer eventos livres de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião. 
-> Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos organizados pela comunidade. 
-> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossos eventos - isto inclui as palestras, apresentações, exemplos ou demonstrações. 
-> Os participantes que violarem estas regras podem ser repreendidos ou expulsos do evento sem direito a reembolso, a critério da organização do mesmo. 
+> O **PHPSP** está comprometido a oferecer uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
+> Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos e canais organizados pela comunidade.
+> Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chats e quaisquer outro canal da comunidade.
+> Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
 > Nosso código de conduta pode ser encontrado na íntegra em [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta.md].
 
 ### Versão Longa
 
-O **PHPSP** está comprometido a oferecer eventos livres de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião. 
-Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos organizados pela comunidade. 
-Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossos eventos - isto inclui as palestras, apresentações, exemplos ou demonstrações. 
-Os participantes que violarem estas regras podem ser repreendidos ou expulsos do evento sem direito a reembolso, a critério da organização do mesmo. 
-
-Entendemos como assédio e constrangimento: 
-comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião; imagens sexuais em espaços públicos; intimidação intencional; perseguição; obtenção de som ou imagem constrangedores; interrupção continuada e intencional de palestras e/ou eventos paralelos; 
-contato físico inapropriado; atenção sexual não solicitada. 
-Os participantes solicitados a parar com o comportamento inadequado devem fazê-lo de imediato.
-
-Representantes de mantenedores, patrocinadores, parceiros, fornecedores e quaisquer atividades similares estão igualmente sujeitos às mesmas regras deste código de conduta. 
-Em especial os estandes não devem promover imagens, impressos, atividades ou qualquer outro material com cunho sexual. 
-Os representantes dos estandes, incluindo voluntários, não devem trajar-se de maneira sexualizada, bem como não devem criar um ambiente sexualizado.
-
-Se um participante apresentar comportamento constrangedor, os organizadores do evento podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a espulsão do agressor, sem reembolso do valor pago para participar do evento se aplicável.
-
-Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contactar um membro da organização do evento imediatamente. 
-As pessoas responsáveis pela organização serão apresentadas ao início dos eventos e podem ser facilmente identificados por camisetas e/ou crachás.
-
-Embora o desejo seja de que isso não venha a ser necessário, caso seja preciso a organização ajudará os participantes no contato com a segurança do local ou com a polícia ou mesmo providenciando escolta.
-Faremos o possível para que todos sintam-se confortáveis e seguros.
-
-Contamos com sua compreensão e participação.
-
-* Contato para eventos do **PHPSP**: eventos@phpsp.org.br
-* [Local do evento]: [Telefone do local]
-* Polícia: 190
-* Central de Atendimento à Mulher: 180
-* SAMU: 192
-
-Esperamos que todos os participantes sigam estas recomendações em todos os locais onde o **PHPSP** estiver levando um evento.
-
-Aproveitem saudavelmente o evento!
+Comunidade: [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta-comunidade.md]
+Eventos: [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta-eventos.md]

--- a/codigo-de-conduta.md
+++ b/codigo-de-conduta.md
@@ -8,7 +8,7 @@
 > Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.
 > Entendemos como assédio e constrangimento:
 
-> * comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
+> * comentários que reforçam estruturas sociais de dominação, sejam relacionados a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião;
 > * imagens sexuais em espaços públicos; 
 > * intimidação intencional; 
 > * perseguição;

--- a/codigo-de-conduta.md
+++ b/codigo-de-conduta.md
@@ -2,7 +2,7 @@
 
 ### Versão curta
 
-> O **PHPSP** está comprometido a oferecer uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
+> O **PHPSP** está comprometido a ser uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.
 > Não será tolerado, sob nenhuma circunstância, o constrangimento de participantes em eventos e canais organizados pela comunidade.
 > Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não serão apropriadas no âmbito de nossa comunidade - isto inclui os eventos, as palestras, apresentações, exemplos ou demonstrações, site, emails, chats e quaisquer outro canal da comunidade.
 > Os participantes que violarem estas regras podem ser repreendidos ou expulsos do canal e/ou evento sem direito a reembolso, a critério da organização.

--- a/codigo-de-conduta.md
+++ b/codigo-de-conduta.md
@@ -16,31 +16,20 @@ Linguagem e/ou exposição de imagens sexuais ou de cunho discriminatório não 
 Os participantes que violarem estas regras podem ser repreendidos ou expulsos do evento sem direito a reembolso, a critério da organização do mesmo. 
 
 Entendemos como assédio e constrangimento: 
-comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, 
-orientação sexual, deficiência, aparência física, raça, idade, origem ou religião; imagens sexuais em espaços públicos; 
-intimidação intencional; perseguição; obtenção de som ou imagem constrangedores; 
-interrupção continuada e intencional de palestras e/ou eventos paralelos; 
+comentários que reforçam estruturas sociais de dominação, seja relacionado a gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião; imagens sexuais em espaços públicos; intimidação intencional; perseguição; obtenção de som ou imagem constrangedores; interrupção continuada e intencional de palestras e/ou eventos paralelos; 
 contato físico inapropriado; atenção sexual não solicitada. 
 Os participantes solicitados a parar com o comportamento inadequado devem fazê-lo de imediato.
 
-Representantes de mantenedores, patrocinadores, parceiros, fornecedores e quaisquer atividades similares estão 
-igualmente sujeitos às mesmas regras deste código de conduta. 
+Representantes de mantenedores, patrocinadores, parceiros, fornecedores e quaisquer atividades similares estão igualmente sujeitos às mesmas regras deste código de conduta. 
 Em especial os estandes não devem promover imagens, impressos, atividades ou qualquer outro material com cunho sexual. 
-Os representantes dos estandes, incluindo voluntários, não devem trajar-se de maneira sexualizada, 
-bem como não devem criar um ambiente sexualizado.
+Os representantes dos estandes, incluindo voluntários, não devem trajar-se de maneira sexualizada, bem como não devem criar um ambiente sexualizado.
 
-Se um participante apresentar comportamento constrangedor, os organizadores do evento podem tomar quaisquer 
-ações a seu critério, incluindo uma advertência verbal ou mesmo a espulsão do agressor, 
-sem reembolso do valor pago para participar do evento se aplicável.
+Se um participante apresentar comportamento constrangedor, os organizadores do evento podem tomar quaisquer ações a seu critério, incluindo uma advertência verbal ou mesmo a espulsão do agressor, sem reembolso do valor pago para participar do evento se aplicável.
 
-Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, 
-ou se tiver qualquer preocupação a respeito deste tema, 
-não deixe de contactar um membro da organização do evento imediatamente. 
-As pessoas responsáveis pela organização serão apresentadas ao início dos eventos e podem ser facilmente 
-identificados por camisetas e/ou crachás.
+Se você estiver sendo assediado(a) ou se sentir constrangido(a), ou perceber alguém nesta condição, ou se tiver qualquer preocupação a respeito deste tema, não deixe de contactar um membro da organização do evento imediatamente. 
+As pessoas responsáveis pela organização serão apresentadas ao início dos eventos e podem ser facilmente identificados por camisetas e/ou crachás.
 
-Embora o desejo seja de que isso não venha a ser necessário, caso seja preciso a organização ajudará 
-os participantes no contato com a segurança do local ou com a polícia ou mesmo providenciando escolta. 
+Embora o desejo seja de que isso não venha a ser necessário, caso seja preciso a organização ajudará os participantes no contato com a segurança do local ou com a polícia ou mesmo providenciando escolta.
 Faremos o possível para que todos sintam-se confortáveis e seguros.
 
 Contamos com sua compreensão e participação.


### PR DESCRIPTION
Separa o CoC de eventos e da comunidade para que o da comunidade passe a citar os canais oficiais da comunidade.
