### PR TITLE
Alterando links do cod conduta

### DIFF
--- a/codigo-de-conduta-comunidade.md
+++ b/codigo-de-conduta-comunidade.md
@@ -16,8 +16,6 @@
 > * interrupção continuada e intencional de palestras e/ou eventos paralelos;
 > * contato físico inapropriado; atenção sexual não solicitada;
 
-> Nosso código de conduta pode ser encontrado na íntegra em [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta.md].
-
 ### Versão Longa
 
 O **PHPSP** está comprometido a ser uma comunidade livre de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.

--- a/codigo-de-conduta-eventos.md
+++ b/codigo-de-conduta-eventos.md
@@ -16,8 +16,6 @@
 > * interrupção continuada e intencional de palestras e/ou eventos paralelos;
 > * contato físico inapropriado; atenção sexual não solicitada;
 
-> Nosso código de conduta pode ser encontrado na íntegra em [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta.md].
-
 ### Versão Longa
 
 O **PHPSP** está comprometido a oferecer eventos livres de discriminação para todos, independente de gênero, identidade e expressão de gênero, orientação sexual, deficiência, aparência física, raça, idade, origem ou religião.

--- a/codigo-de-conduta.md
+++ b/codigo-de-conduta.md
@@ -16,7 +16,7 @@
 > * interrupção continuada e intencional de palestras e/ou eventos paralelos;
 > * contato físico inapropriado; atenção sexual não solicitada;
 
-> Nosso código de conduta pode ser encontrado na íntegra em [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta.md].
+> Nosso código de conduta pode ser encontrado na íntegra em [https://github.com/PHPSP/docs/blob/master/codigo-de-conduta-comunidade.md].
 
 ### Versões longas e específicas 
 


### PR DESCRIPTION
- Havia link com redundância;
- Haviam links com descrições erradas nas versões longas, enviando novamente para a versão curta.
